### PR TITLE
Sonnet's base AbstractModule now requires named arguments (Sonnet v1.6 and Python 3)

### DIFF
--- a/networks.py
+++ b/networks.py
@@ -171,7 +171,7 @@ class StandardDeepLSTM(Network):
           "zeros" will be converted to tf.zeros_initializer).
       name: Module name.
     """
-    super(StandardDeepLSTM, self).__init__(name)
+    super(StandardDeepLSTM, self).__init__(name=name)
 
     self._output_size = output_size
     self._scale = scale
@@ -318,7 +318,7 @@ class Sgd(Network):
       learning_rate: constant learning rate to use.
       name: Module name.
     """
-    super(Sgd, self).__init__(name)
+    super(Sgd, self).__init__(name=name)
     self._learning_rate = learning_rate
 
   def _build(self, inputs, _):


### PR DESCRIPTION
To use a recent version of Sonnet, I did changes regarding the new behavior, see: https://github.com/deepmind/sonnet/commit/601c4f393037ea76c625d39c88d9d576f438c7ae

The tests pass, except for two parameterizations of `testValues` in `QuadraticTest` of `problems_test.py`. It looks like floating points rounding errors that are somehow unrelated to my changes: 
```
======================================================================
FAIL: testValues_0 (__main__.QuadraticTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ubuntu/miniconda/lib/python3.6/site-packages/nose_parameterized/parameterized.py", line 392, in standalone_func
    return func(*(a + p.args), **p.kwargs)
  File "problems_test.py", line 111, in testValues
    self.assertEqual(output, ((w * value) - y)**2)
AssertionError: 24.999998 != 25.0

======================================================================
FAIL: testValues_3 (__main__.QuadraticTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ubuntu/miniconda/lib/python3.6/site-packages/nose_parameterized/parameterized.py", line 392, in standalone_func
    return func(*(a + p.args), **p.kwargs)
  File "problems_test.py", line 111, in testValues
    self.assertEqual(output, ((w * value) - y)**2)
AssertionError: 288.99997 != 289.0
```

I tested the changes under:
- Sonnet v1.6
- TensorFlow 1.2 (with GPU)
- Python 3.6.1 (miniconda)
- Ubuntu 16.04
- Amazon AWS p2 instance (1 x Tesla K80)
